### PR TITLE
[PORT] Faz Port do buff das SMES do Einstein-Engines (EE #1752)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -60,11 +60,10 @@
       voltage: High
       node: input
     - type: PowerNetworkBattery
-       # Goobstation - SMES buff
-      maxSupply: 300000
-      maxChargeRate: 10000
-      supplyRampTolerance: 10000
-      supplyRampRate: 2000
+      maxSupply: 750000
+      maxChargeRate: 25000
+      supplyRampTolerance: 25000
+      supplyRampRate: 5000
     - type: PointLight
       radius: 1.5
       energy: 1.6
@@ -105,12 +104,11 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 16MJ
+  suffix: Basic, 120MW
   components:
   - type: Battery
-     # Goobstation - SMES buff
-    maxCharge: 16000000
-    startingCharge: 16000000
+    maxCharge: 120000000
+    startingCharge: 120000000
 
 - type: entity
   parent: SMESBasic
@@ -123,7 +121,7 @@
 - type: entity
   parent: BaseSMES
   id: SMESAdvanced
-  suffix: Advanced, 32MJ
+  suffix: Advanced, 480MJ
   name: advanced SMES
   description: An even-higher-capacity superconducting magnetic energy storage (SMES) unit.
   components:


### PR DESCRIPTION
## About the PR
Faz as SMES durarem mais tempo armazenando mais energia.

## Why / Balance
Por que é um lixo a energia acabar em 2 minutos de turno por que a SMES ficou vazia, tipo, nao era para ele servir como uma bateria?

## Media
nao necessário

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
SMES duram muito mais tempo agora

**Changelog**

:cl: Emilly
- tweak: Stations SMES now store 120MW of power, up from 8MW. They should actually do what they are intended to do now.

