### PR TITLE
[PORT] Faz port de QOL para a IA do EE (Einstein-Engine #1761)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -289,6 +289,8 @@
     - id: ClothingHeadsetAltScience
     - id: DoorRemoteResearch
     - id: HandTeleporter
+    - id: StationAiUploadCircuitboard
+    - id: RoboticsConsoleCircuitboard
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: CargoRequestScienceComputerCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -541,8 +541,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: StationAiUploadCircuitboard
-  name: AI upload console board
-  description: A computer printed circuit board for a AI upload console.
+  name: station ai upload console board
+  description: A computer printed circuit board for a station AI upload console.
   components:
     - type: Sprite
       state: cpu_science

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -81,6 +81,7 @@
   - type: GuideHelp
     guides:
     - Pumps
+  - type: StationAiWhitelist
 
 - type: entity
   parent: GasBinaryBase
@@ -146,6 +147,7 @@
     - type: GuideHelp
       guides:
       - Pumps
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasBinaryBase
@@ -183,6 +185,7 @@
     - type: GuideHelp
       guides:
       - PassiveGate
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasBinaryBase
@@ -239,6 +242,7 @@
     - type: GuideHelp
       guides:
       - ManualValve
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasBinaryBase
@@ -306,7 +310,7 @@
   - type: GuideHelp
     guides:
     - SignalValve
-
+    - type: StationAiWhitelist
 - type: entity
   parent: GasBinaryBase
   id: GasPort
@@ -343,6 +347,7 @@
     - type: GuideHelp
       guides:
       - GasCanisters
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasVentPump
@@ -407,6 +412,7 @@
     - type: GuideHelp
       guides:
       - AirVent
+    - type: StationAiWhitelist
 
 - type: entity
   parent: [ BaseMachine, ConstructibleMachine ]
@@ -602,3 +608,4 @@
     - type: GuideHelp
       guides:
       - ManualValve
+    - type: StationAiWhitelist

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -78,6 +78,7 @@
     - type: GuideHelp
       guides:
       - MixingAndFiltering
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasFilter
@@ -177,6 +178,7 @@
     - type: GuideHelp
       guides:
       - MixingAndFiltering
+    - type: StationAiWhitelist
 
 - type: entity
   parent: GasMixer
@@ -285,3 +287,4 @@
       - PneumaticValve
       - Pumps
       - Valves
+    - type: StationAiWhitelist

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -27,6 +27,7 @@
     layoutId: ParticleAccelerator
   - type: AccessReader
     access: [["Engineering"]]
+  - type: StationAiWhitelist
 
 # Unfinished
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -103,3 +103,4 @@
       - On
       - Off
       - Toggle
+  - type: StationAiWhitelist


### PR DESCRIPTION


## About the PR
Comentario da PR original:
"Needed for antagonistic AI gameplay. Currently any variant of "Antagonistic AI" is extremely limited in their options for harming crew. Traditionally SS13 AIs would have had a larger variety of options for Harming Crew, the most iconic of which was by Plasmaflooding. With this change, AI can "Assist" in setting up Atmos by turning on pumps and configuring gas mixers to provide the station with breathable air. Or a more murderous AI can "Assist" by configuring the air supply to include plasma.

Also whitelists the Emitters and Singularity Controller for the same purpose.

The Research Director now starts with a spare AI Upload circuitboard."

## Why / Balance
melhorar QOL de jogadores de IA

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Emilly
- add: IA agora consegue utilizar canos, como bombas de ar, filtros, mixer, etc, tambem pode utilizar emitters e o controle PA.
- tweak: adicionado placa do AIUpload e RoboticsControl no armario do RD

