### PR TITLE
Mostra vida no crew monitoring

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -272,6 +272,16 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             statusContainer.AddChild(statusIcon);
 
+            // Health Value
+            var healthLabel = new Label()
+            {
+                Text = sensor.TotalDamage.ToString(),
+                HorizontalExpand = true,
+                ClipText = true,
+            };
+
+            statusContainer.AddChild(healthLabel);
+
             // User name
             var nameLabel = new Label()
             {


### PR DESCRIPTION
# Description

Mostra dano total no pc da Crew Monitoring
---



<summary><h1>Media</h1></summary>

<img width="402" height="177" alt="image" src="https://github.com/user-attachments/assets/b3d84d83-b4c6-4c5d-af5c-7e1ea93c91e0" />
(ANTES)
<img width="349" height="135" alt="image" src="https://github.com/user-attachments/assets/ca3c0b03-ef38-4550-8f9d-397920f73f4a" />
(DEPOIS)


---

# Changelog

:cl:
- add: Label para a janela da crew monitoring
